### PR TITLE
:+1: Add plugin name support

### DIFF
--- a/denops_test/tester.ts
+++ b/denops_test/tester.ts
@@ -17,6 +17,8 @@ export interface TestDefinition extends Omit<Deno.TestDefinition, "fn"> {
    * When "all" is specified, the test is run with both Vim and Neovim.
    */
   mode: TestMode;
+  /** Plugin name of test target */
+  pluginName?: string;
   /** Print Vim messages (echomsg) */
   verbose?: boolean;
   /** Vim commands to be executed before the start of Denops */
@@ -101,6 +103,7 @@ function testInternal(def: TestDefinition): void {
       ...def,
       fn: (t) => {
         return withDenops(mode, (denops) => def.fn(denops, t), {
+          pluginName: def.pluginName,
           verbose: def.verbose,
           prelude: def.prelude,
           postlude: def.postlude,


### PR DESCRIPTION
This PR add plugin name specifier from old denops test module.

I want to test using Vim script and I want the following code to work.

```
test({
  pluginName: "example",
  mode: "all",
  name: "can call plugin function from Vim",
  fn: async (denops) => {
    assertEquals(
      await denops.call("denops#request", "example", "function", []),
      "result",
    );
  },
});
```