### PR TITLE
:+1: Improved test error handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ used in the unit tests of denops plugins.
 > - `DENOPS_TEST_NVIM_EXECUTABLE`: Path to the Neovim executable (default:
 >   "nvim")
 > - `DENOPS_TEST_VERBOSE`: `1` or `true` to print Vim messages (echomsg)
+> - `DENOPS_TEST_CONNECT_TIMEOUT`: Timeout [ms] for connecting to Vim/Neovim
+>   (default: 30000)
 
 If you want to test denops plugins with a real Vim and/or Neovim process, use
 the `test` function to define a test case, as shown below:

--- a/conf.ts
+++ b/conf.ts
@@ -29,6 +29,12 @@ export interface Config {
    * It refers to the environment variable 'DENOPS_TEST_VERBOSE'.
    */
   verbose: boolean;
+
+  /**
+   * Timeout for connecting to Vim/Neovim.
+   * It refers to the environment variable 'DENOPS_TEST_CONNECT_TIMEOUT'.
+   */
+  connectTimeout?: number;
 }
 
 /**
@@ -43,6 +49,7 @@ export interface Config {
  * - `DENOPS_TEST_VIM_EXECUTABLE`: Path to the Vim executable (default: "vim")
  * - `DENOPS_TEST_NVIM_EXECUTABLE`: Path to the Neovim executable (default: "nvim")
  * - `DENOPS_TEST_VERBOSE`: `1` or `true` to print Vim messages (echomsg)
+ * - `DENOPS_TEST_CONNECT_TIMEOUT`: Timeout [ms] for connecting to Vim/Neovim (default: 30000)
  *
  * It throws an error if the environment variable 'DENOPS_TEST_DENOPS_PATH' is
  * not set.
@@ -58,11 +65,17 @@ export function getConfig(): Config {
     );
   }
   const verbose = Deno.env.get("DENOPS_TEST_VERBOSE");
+  const connectTimeout = Number.parseInt(
+    Deno.env.get("DENOPS_TEST_CONNECT_TIMEOUT") ?? "",
+  );
   conf = {
     denopsPath: resolve(denopsPath),
     vimExecutable: Deno.env.get("DENOPS_TEST_VIM_EXECUTABLE") ?? "vim",
     nvimExecutable: Deno.env.get("DENOPS_TEST_NVIM_EXECUTABLE") ?? "nvim",
     verbose: verbose === "1" || verbose === "true",
+    connectTimeout: Number.isNaN(connectTimeout) || connectTimeout <= 0
+      ? undefined
+      : connectTimeout,
   };
   return conf;
 }

--- a/runner.ts
+++ b/runner.ts
@@ -1,3 +1,4 @@
+import { mergeReadableStreams } from "https://deno.land/std@0.210.0/streams/merge_readable_streams.ts";
 import { is } from "https://deno.land/x/unknownutil@v3.11.0/mod.ts";
 import { unreachable } from "https://deno.land/x/errorutil@v0.1.1/mod.ts";
 import { Config, getConfig } from "./conf.ts";
@@ -19,6 +20,25 @@ export interface RunOptions
 }
 
 /**
+ * Represents results of the runner.
+ */
+export interface RunResult extends AsyncDisposable {
+  /**
+   * Aborts the process.
+   */
+  close(): void;
+  /**
+   * Wait the process closed and returns status.
+   */
+  waitClosed(): Promise<WaitClosedResult>;
+}
+
+type WaitClosedResult = {
+  status: Deno.CommandStatus;
+  output?: string;
+};
+
+/**
  * Checks if the provided mode is a valid `RunMode`.
  */
 export const isRunMode = is.LiteralOneOf(["vim", "nvim"] as const);
@@ -34,22 +54,51 @@ export function run(
   mode: RunMode,
   cmds: string[],
   options: RunOptions = {},
-): Deno.ChildProcess {
+): RunResult {
   const conf = getConfig();
-  const verbose = options.verbose ?? conf.verbose;
+  const { verbose = conf.verbose } = options;
   const [cmd, args] = buildArgs(conf, mode);
   args.push(...cmds.flatMap((c) => ["-c", c]));
-  if (verbose) {
-    args.unshift("--cmd", "redir >> /dev/stdout");
-  }
+  const aborter = new AbortController();
+  const { signal } = aborter;
   const command = new Deno.Command(cmd, {
     args,
     env: options.env,
     stdin: "piped",
-    stdout: verbose ? "inherit" : "null",
-    stderr: verbose ? "inherit" : "null",
+    stdout: "piped",
+    stderr: "piped",
+    signal,
   });
-  return command.spawn();
+  const proc = command.spawn();
+  let outputStream = mergeReadableStreams(
+    proc.stdout.pipeThrough(new TextDecoderStream(), { signal }),
+    proc.stderr.pipeThrough(new TextDecoderStream(), { signal }),
+  );
+  if (verbose) {
+    const [consoleStream] = [, outputStream] = outputStream.tee();
+    consoleStream.pipeTo(
+      new WritableStream({ write: (data) => console.error(data) }),
+    ).catch(() => {});
+  }
+  return {
+    close() {
+      aborter.abort("close");
+    },
+    async waitClosed() {
+      const [status, output] = await Promise.all([
+        proc.status,
+        Array.fromAsync(outputStream)
+          .then((list) => list.join(""))
+          .catch(() => undefined),
+      ]);
+      await proc.stdin.abort();
+      return { status, output };
+    },
+    async [Symbol.asyncDispose]() {
+      this.close();
+      await this.waitClosed();
+    },
+  };
 }
 
 function buildArgs(conf: Config, mode: RunMode): [string, string[]] {
@@ -67,6 +116,7 @@ function buildArgs(conf: Config, mode: RunMode): [string, string[]] {
           "-X", // Disable xterm
           "-e", // Start Vim in Ex mode
           "-s", // Silent or batch mode ("-e" is required before)
+          "-V1", // Verbose level 1 (Echo messages to stderr)
           "-c",
           "visual", // Go to Normal mode
         ],
@@ -74,7 +124,12 @@ function buildArgs(conf: Config, mode: RunMode): [string, string[]] {
     case "nvim":
       return [
         conf.nvimExecutable,
-        ["--clean", "--embed", "--headless", "-n"],
+        [
+          "--clean",
+          "--headless",
+          "-n", // Disable swap file
+          "-V1", // Verbose level 1 (Echo messages to stderr)
+        ],
       ];
     default:
       unreachable(mode);

--- a/with_test.ts
+++ b/with_test.ts
@@ -1,29 +1,61 @@
 import {
   assert,
   assertFalse,
+  assertRejects,
 } from "https://deno.land/std@0.210.0/assert/mod.ts";
+import {
+  assertSpyCalls,
+  spy,
+} from "https://deno.land/std@0.210.0/testing/mock.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v6.0.2/mod.ts";
 import { withDenops } from "./with.ts";
 
-Deno.test(
-  "test(mode:vim) start vim to test denops features",
-  async () => {
-    let called = false;
-    await withDenops("vim", async (denops) => {
-      assertFalse(await denops.call("has", "nvim"));
-      called = true;
-    });
-    assert(called, "withDenops main is not called");
-  },
-);
+Deno.test("test(mode:vim) start vim to test denops features", async () => {
+  const main = spy(async (denops: Denops) => {
+    assertFalse(await denops.call("has", "nvim"));
+  });
+  await withDenops("vim", main);
+  assertSpyCalls(main, 1);
+});
 
-Deno.test(
-  "test(mode:nvim) start vim to test denops features",
-  async () => {
-    let called = false;
-    await withDenops("nvim", async (denops) => {
-      assert(await denops.call("has", "nvim"));
-      called = true;
-    });
-    assert(called, "withDenops main is not called");
-  },
-);
+Deno.test("test(mode:nvim) start nvim to test denops features", async () => {
+  const main = spy(async (denops: Denops) => {
+    assert(await denops.call("has", "nvim"));
+  });
+  await withDenops("nvim", main);
+  assertSpyCalls(main, 1);
+});
+
+for (const mode of ["vim", "nvim"] as const) {
+  Deno.test(`test(mode:${mode}) rejects if process aborted`, async () => {
+    const fn = spy(() => {});
+    await assertRejects(
+      async () => {
+        await withDenops(mode, fn, {
+          prelude: [
+            "echomsg 'foobar'",
+            "cquit",
+          ],
+        });
+      },
+      Error,
+      "foobar",
+    );
+    assertSpyCalls(fn, 0);
+  });
+
+  Deno.test(`test(mode:${mode}) rejects if connection failed`, async () => {
+    const fn = spy(() => {});
+    await assertRejects(
+      async () => {
+        await withDenops(mode, fn, {
+          prelude: ["sleep 1"], // Set sleep [s] longer than timeout
+          connectTimeout: 10, // Set timeout [ms] shorter than sleep
+        });
+      },
+      Error,
+      "Connection failed",
+    );
+    assertSpyCalls(fn, 0);
+  });
+}


### PR DESCRIPTION
Improved test error handling.

- When Vim/Nvim process startup fails, always wait for a connection timeout. Fixed to finish quickly.
- If the process terminates abnormally, include the console output in the exception message.
- Console output (`verbose=true`) was not supported on Windows. Supported now.
- Add `DENOPS_TEST_CONNECT_TIMEOUT` environment variable.
- Refactoring by `using`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Enhanced connection handling in `withDenops` function by restructuring logic for improved error management and operational efficiency.
- **Documentation**
	- Updated configuration details indentation in the README for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->