### PR TITLE
Support Denops v7 and publish package on JSR

### DIFF
--- a/.github/workflows/jsr.yml
+++ b/.github/workflows/jsr.yml
@@ -1,0 +1,27 @@
+name: jsr
+
+env:
+  DENO_VERSION: 1.x
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+      - name: Publish
+        run: |
+          deno run -A jsr:@david/publish-on-tag@0.1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,3 +113,14 @@ jobs:
           os: ${{ runner.os }}
           files: ./coverage.lcov
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  jsr-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: "1.x"
+      - name: Publish (dry-run)
+        run: |
+          deno publish --dry-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,11 @@ jobs:
           - macos-latest
           - ubuntu-latest
         deno_version:
-          - "1.38.x"
+          - "1.43.x"
           - "1.x"
         host_version:
-          - vim: "v9.0.2189"
-            nvim: "v0.9.4"
+          - vim: "v9.1.0399"
+            nvim: "v0.9.5"
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
       - name: Update dependencies and commit changes
-        run: deno task -q upgrade:commit --summary ../title.txt --report ../body.md
+        run: deno task -q update:commit --summary ../title.txt --report ../body.md
       - name: Check result
         id: result
         uses: andstor/file-existence-action@v2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # 📝 denops_test
 
+[![JSR](https://jsr.io/badges/@denops/test)](https://jsr.io/@denops/test)
 [![Test](https://github.com/vim-denops/deno-denops-test/actions/workflows/test.yml/badge.svg)](https://github.com/vim-denops/deno-denops-test/actions/workflows/test.yml)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/denops_test/mod.ts)
-[![deno land](http://img.shields.io/badge/available%20on-deno.land/x/denops__test-lightgrey.svg?logo=deno)](https://deno.land/x/denops_test)
 [![codecov](https://codecov.io/github/vim-denops/deno-denops-test/branch/main/graph/badge.svg?token=X9O5XB4O1S)](https://codecov.io/github/vim-denops/deno-denops-test)
 
 A [Deno] module designed for testing [denops.vim]. This module is intended to be

--- a/README.md
+++ b/README.md
@@ -31,12 +31,8 @@ If you want to test denops plugins with a real Vim and/or Neovim process, use
 the `test` function to define a test case, as shown below:
 
 ```typescript
-import {
-  assert,
-  assertEquals,
-  assertFalse,
-} from "https://deno.land/std@0.210.0/assert/mod.ts";
-import { test } from "https://deno.land/x/denops_test@$MODULE_VERSION/mod.ts";
+import { assert, assertEquals, assertFalse } from "jsr:@std/assert";
+import { test } from "jsr:@denops/test";
 
 test("vim", "Start Vim to test denops features", async (denops) => {
   assertFalse(await denops.call("has", "nvim"));
@@ -72,8 +68,8 @@ the `DenopsStub` class to create a stub instance of the `Denops` interface, as
 shown below:
 
 ```typescript
-import { assertEquals } from "https://deno.land/std@0.210.0/assert/mod.ts";
-import { DenopsStub } from "https://deno.land/x/denops_test@$MODULE_VERSION/mod.ts";
+import { assertEquals } from "jsr:@std/assert";
+import { DenopsStub } from "jsr:@denops/test";
 
 Deno.test("denops.call", async () => {
   const denops = new DenopsStub({
@@ -157,6 +153,10 @@ jobs:
       - name: Run tests
         run: deno test -A
 ```
+
+## For developers
+
+This library may be called from denops itself so import map is not available.
 
 ## License
 

--- a/conf.ts
+++ b/conf.ts
@@ -1,4 +1,4 @@
-import { resolve } from "https://deno.land/std@0.210.0/path/mod.ts";
+import { resolve } from "jsr:@std/path@0.225.0/resolve";
 
 let conf: Config | undefined;
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,4 +1,12 @@
 {
+  "name": "@denops/test",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./mod.ts",
+    "./stub": "./stub.ts",
+    "./tester": "./tester.ts",
+    "./with": "./with.ts"
+  },
   "tasks": {
     "check": "deno check **/*.ts",
     "test": "deno test -A --doc --parallel --shuffle",
@@ -8,6 +16,6 @@
     "update:commit": "deno task -q update --commit --pre-commit=fmt,lint"
   },
   "imports": {
-    "https://deno.land/x/denops_test@$MODULE_VERSION/": "./"
+    "jsr:@denops/test": "./mod.ts"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,8 +4,8 @@
     "test": "deno test -A --doc --parallel --shuffle",
     "test:coverage": "deno task test --coverage=.coverage",
     "coverage": "deno coverage .coverage",
-    "upgrade": "deno run -q -A https://deno.land/x/molt@0.14.2/cli.ts ./**/*.ts",
-    "upgrade:commit": "deno task -q upgrade --commit --prefix :package: --pre-commit=fmt"
+    "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=jsr.io,registry.npmjs.org jsr:@molt/cli ./*.ts",
+    "update:commit": "deno task -q update --commit --pre-commit=fmt,lint"
   },
   "imports": {
     "https://deno.land/x/denops_test@$MODULE_VERSION/": "./"

--- a/denops.ts
+++ b/denops.ts
@@ -1,10 +1,5 @@
-import type {
-  Context,
-  Denops,
-  Dispatcher,
-  Meta,
-} from "https://deno.land/x/denops_core@v6.0.2/mod.ts";
-import { Client } from "https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts";
+import type { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@6.0.6";
+import { Client } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
 
 export class DenopsImpl implements Denops {
   readonly name: string;

--- a/denops.ts
+++ b/denops.ts
@@ -1,5 +1,5 @@
 import type { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@6.0.6";
-import { Client } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
+import type { Client } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
 
 export class DenopsImpl implements Denops {
   readonly name: string;

--- a/error.ts
+++ b/error.ts
@@ -1,10 +1,10 @@
-import { is } from "https://deno.land/x/unknownutil@v3.11.0/mod.ts";
+import { is } from "jsr:@core/unknownutil@3.18.0";
 import {
   fromErrorObject,
   isErrorObject,
   toErrorObject,
   tryOr,
-} from "https://deno.land/x/errorutil@v0.1.1/mod.ts";
+} from "jsr:@lambdalisue/errorutil@1.0.0";
 
 export function errorSerializer(err: unknown): unknown {
   if (err instanceof Error) {

--- a/mod.ts
+++ b/mod.ts
@@ -27,8 +27,8 @@
  *   assert,
  *   assertEquals,
  *   assertFalse,
- * } from "https://deno.land/std@0.210.0/assert/mod.ts";
- * import { test } from "https://deno.land/x/denops_test@$MODULE_VERSION/mod.ts";
+ * } from "jsr:@std/assert";
+ * import { test } from "jsr:@denops/test";
  *
  * test(
  *   "vim",
@@ -68,8 +68,8 @@
  * shown below:
  *
  * ```typescript
- * import { assertEquals } from "https://deno.land/std@0.210.0/assert/mod.ts";
- * import { DenopsStub } from "https://deno.land/x/denops_test@$MODULE_VERSION/mod.ts";
+ * import { assertEquals } from "jsr:@std/assert";
+ * import { DenopsStub } from "jsr:@denops/test";
  *
  * Deno.test("denops.call", async () => {
  *   const denops = new DenopsStub({

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,13 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_core@v6.0.2/mod.ts";
-import {
-  assert,
-  ensure,
-  is,
-} from "https://deno.land/x/unknownutil@v3.11.0/mod.ts";
-import {
-  Client,
-  Session,
-} from "https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts";
+import type { Denops } from "jsr:@denops/core@6.0.6";
+import { assert, ensure, is } from "jsr:@core/unknownutil@3.18.0";
+import { Client, Session } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
 import { errorDeserializer, errorSerializer } from "./error.ts";
 
 export async function main(denops: Denops): Promise<void> {

--- a/runner.ts
+++ b/runner.ts
@@ -1,7 +1,7 @@
 import { mergeReadableStreams } from "jsr:@std/streams@0.224.0/merge-readable-streams";
 import { is } from "jsr:@core/unknownutil@3.18.0";
 import { unreachable } from "jsr:@lambdalisue/errorutil@1.0.0";
-import { Config, getConfig } from "./conf.ts";
+import { type Config, getConfig } from "./conf.ts";
 
 /**
  * Represents the mode in which the runner operates.

--- a/runner.ts
+++ b/runner.ts
@@ -1,6 +1,6 @@
-import { mergeReadableStreams } from "https://deno.land/std@0.210.0/streams/merge_readable_streams.ts";
-import { is } from "https://deno.land/x/unknownutil@v3.11.0/mod.ts";
-import { unreachable } from "https://deno.land/x/errorutil@v0.1.1/mod.ts";
+import { mergeReadableStreams } from "jsr:@std/streams@0.224.0/merge-readable-streams";
+import { is } from "jsr:@core/unknownutil@3.18.0";
+import { unreachable } from "jsr:@lambdalisue/errorutil@1.0.0";
 import { Config, getConfig } from "./conf.ts";
 
 /**

--- a/stub.ts
+++ b/stub.ts
@@ -1,9 +1,4 @@
-import {
-  Context,
-  Denops,
-  Dispatcher,
-  Meta,
-} from "https://deno.land/x/denops_core@v6.0.2/mod.ts";
+import { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@6.0.6";
 
 /**
  * Represents a stubber object for `Denops`.

--- a/stub.ts
+++ b/stub.ts
@@ -1,4 +1,4 @@
-import { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@6.0.6";
+import type { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@6.0.6";
 
 /**
  * Represents a stubber object for `Denops`.

--- a/stub_test.ts
+++ b/stub_test.ts
@@ -1,6 +1,6 @@
 import { assertSpyCall, spy } from "jsr:@std/testing@0.224.0/mock";
 import { assertEquals } from "jsr:@std/assert@0.225.1";
-import { Denops } from "jsr:@denops/core@6.0.6";
+import type { Denops } from "jsr:@denops/core@6.0.6";
 import { DenopsStub } from "./stub.ts";
 
 Deno.test("`DenopsStub`", async (t) => {

--- a/stub_test.ts
+++ b/stub_test.ts
@@ -1,9 +1,6 @@
-import {
-  assertSpyCall,
-  spy,
-} from "https://deno.land/std@0.210.0/testing/mock.ts";
-import { assertEquals } from "https://deno.land/std@0.210.0/assert/mod.ts";
-import { Denops } from "https://deno.land/x/denops_core@v6.0.2/mod.ts";
+import { assertSpyCall, spy } from "jsr:@std/testing@0.224.0/mock";
+import { assertEquals } from "jsr:@std/assert@0.225.1";
+import { Denops } from "jsr:@denops/core@6.0.6";
 import { DenopsStub } from "./stub.ts";
 
 Deno.test("`DenopsStub`", async (t) => {

--- a/tester.ts
+++ b/tester.ts
@@ -1,5 +1,5 @@
-import { sample } from "https://deno.land/std@0.210.0/collections/sample.ts";
-import type { Denops } from "https://deno.land/x/denops_core@v6.0.2/mod.ts";
+import { sample } from "jsr:@std/collections@0.224.1/sample";
+import type { Denops } from "jsr:@denops/core@6.0.6";
 import type { RunMode } from "./runner.ts";
 import { withDenops } from "./with.ts";
 
@@ -45,8 +45,8 @@ export interface TestDefinition extends Omit<Deno.TestDefinition, "fn"> {
  * tests by passing a `denops` instance to the registered test function.
  *
  * ```ts
- * import { assert, assertFalse } from "https://deno.land/std@0.210.0/assert/mod.ts";
- * import { test } from "https://deno.land/x/denops_test@$MODULE_VERSION/mod.ts";
+ * import { assert, assertFalse } from "jsr:@std/assert";
+ * import { test } from "jsr:@denops/test";
  *
  * test("vim", "Test with Vim", async (denops) => {
  *   assertFalse(await denops.call("has", "nvim"));
@@ -74,8 +74,8 @@ export function test(
  * tests by passing a `denops` instance to the registered test function.
  *
  * ```ts
- * import { assert, assertFalse } from "https://deno.land/std@0.210.0/assert/mod.ts";
- * import { test } from "https://deno.land/x/denops_test@$MODULE_VERSION/mod.ts";
+ * import { assert, assertFalse } from "jsr:@std/assert";
+ * import { test } from "jsr:@denops/test";
  *
  * test({
  *   mode: "nvim",

--- a/tester_test.ts
+++ b/tester_test.ts
@@ -1,8 +1,4 @@
-import {
-  assert,
-  assertEquals,
-  assertFalse,
-} from "https://deno.land/std@0.210.0/assert/mod.ts";
+import { assert, assertEquals, assertFalse } from "jsr:@std/assert@0.225.1";
 import { test } from "./tester.ts";
 
 test({

--- a/with.ts
+++ b/with.ts
@@ -1,13 +1,7 @@
-import { deadline } from "https://deno.land/std@0.210.0/async/mod.ts";
-import { assert, is } from "https://deno.land/x/unknownutil@v3.11.0/mod.ts";
-import {
-  Client,
-  Session,
-} from "https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts";
-import type {
-  Denops,
-  Meta,
-} from "https://deno.land/x/denops_core@v6.0.2/mod.ts";
+import { deadline } from "jsr:@std/async@0.224.0/deadline";
+import { assert, is } from "jsr:@core/unknownutil@3.18.0";
+import { Client, Session } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
+import type { Denops, Meta } from "jsr:@denops/core@6.0.6";
 import { getConfig } from "./conf.ts";
 import { run, RunMode } from "./runner.ts";
 import { DenopsImpl } from "./denops.ts";
@@ -46,8 +40,8 @@ export interface WithDenopsOptions {
  * internally spawns a Vim/Neovim sub-process, which performs the tests.
  *
  * ```ts
- * import { assert, assertFalse } from "https://deno.land/std@0.210.0/assert/mod.ts";
- * import { withDenops } from "https://deno.land/x/denops_test@$MODULE_VERSION/mod.ts";
+ * import { assert, assertFalse } from "jsr:@std/assert";
+ * import { withDenops } from "jsr:@denops/test";
  *
  * Deno.test("Test Denops (Vim)", async () => {
  *   await withDenops("vim", async (denops) => {

--- a/with.ts
+++ b/with.ts
@@ -3,7 +3,7 @@ import { assert, is } from "jsr:@core/unknownutil@3.18.0";
 import { Client, Session } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
 import type { Denops, Meta } from "jsr:@denops/core@6.0.6";
 import { getConfig } from "./conf.ts";
-import { run, RunMode } from "./runner.ts";
+import { run, type RunMode } from "./runner.ts";
 import { DenopsImpl } from "./denops.ts";
 import { errorDeserializer, errorSerializer } from "./error.ts";
 

--- a/with_test.ts
+++ b/with_test.ts
@@ -1,13 +1,6 @@
-import {
-  assert,
-  assertFalse,
-  assertRejects,
-} from "https://deno.land/std@0.210.0/assert/mod.ts";
-import {
-  assertSpyCalls,
-  spy,
-} from "https://deno.land/std@0.210.0/testing/mock.ts";
-import type { Denops } from "https://deno.land/x/denops_core@v6.0.2/mod.ts";
+import { assert, assertFalse, assertRejects } from "jsr:@std/assert@0.225.1";
+import { assertSpyCalls, spy } from "jsr:@std/testing@0.224.0/mock";
+import type { Denops } from "jsr:@denops/core@6.0.6";
 import { withDenops } from "./with.ts";
 
 Deno.test("test(mode:vim) start vim to test denops features", async () => {


### PR DESCRIPTION
https://github.com/vim-denops/denops.vim/pull/344
https://jsr.io/@denops/test/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new GitHub Actions workflow for automated publishing using Deno.
  
- **Enhancements**
  - Updated Deno and Vim versions in testing workflows for improved compatibility and performance.
  
- **Refactor**
  - Transitioned all import statements across various modules to use custom `jsr:` prefixed URLs, enhancing modularity and maintainability.

- **Documentation**
  - Updated README to reflect new import paths for testing Denops plugins.

- **Chores**
  - Adjusted configurations and dependencies in `deno.jsonc` to align with new import paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->