### PR TITLE
👍  Improve verbose output and add test for multiline output

### DIFF
--- a/runner.ts
+++ b/runner.ts
@@ -119,6 +119,8 @@ function buildArgs(conf: Config, mode: RunMode): [string, string[]] {
           "-V1", // Verbose level 1 (Echo messages to stderr)
           "-c",
           "visual", // Go to Normal mode
+          "-c",
+          "set columns=9999", // Avoid unwilling output newline
         ],
       ];
     case "nvim":
@@ -129,6 +131,8 @@ function buildArgs(conf: Config, mode: RunMode): [string, string[]] {
           "--headless",
           "-n", // Disable swap file
           "-V1", // Verbose level 1 (Echo messages to stderr)
+          "-c",
+          "set columns=9999", // Avoid unwilling output newline
         ],
       ];
     default:


### PR DESCRIPTION
1. Increase `columns` so that Vim/Neovim does NOT insert unwilling newlines into the verbose output.
2. Clarify the Neovim's verbose output situation by adding multiline test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced text processing by integrating `TextDelimiterStream` to handle text delimiters efficiently.
	- Improved command-line interface for `vim` and `nvim` modes to prevent unwanted output newlines.

- **Refactor**
	- Streamlined handling of output in test environments for different modes, ensuring consistency across `vim` and `nvim`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->