### PR TITLE
:tada: For Denops v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,11 @@ jobs:
           - macos-latest
           - ubuntu-latest
         deno_version:
-          - "1.43.x"
+          - "1.45.x"
           - "1.x"
         host_version:
-          - vim: "v9.1.0399"
-            nvim: "v0.9.5"
+          - vim: "v9.1.0448"
+            nvim: "v0.10.0"
 
     runs-on: ${{ matrix.runner }}
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ jobs:
           - macos-latest
           - ubuntu-latest
         deno_version:
-          - "1.43.x"
+          - "1.45.x"
           - "1.x"
         host_version:
-          - vim: "v9.1.0399"
-            nvim: "v0.9.5"
+          - vim: "v9.1.0448"
+            nvim: "v0.10.0"
 
     runs-on: ${{ matrix.runner }}
 

--- a/conf.ts
+++ b/conf.ts
@@ -1,4 +1,4 @@
-import { resolve } from "jsr:@std/path@0.225.0/resolve";
+import { resolve } from "jsr:@std/path@1.0.1/resolve";
 
 let conf: Config | undefined;
 

--- a/conf_test.ts
+++ b/conf_test.ts
@@ -3,9 +3,9 @@ import {
   assertEquals,
   assertObjectMatch,
   assertThrows,
-} from "jsr:@std/assert@0.225.1";
-import { stub } from "jsr:@std/testing@0.224/mock";
-import { basename, isAbsolute } from "jsr:@std/path@0.224.0";
+} from "jsr:@std/assert@1.0.0";
+import { stub } from "jsr:@std/testing@0.225.3/mock";
+import { basename, isAbsolute } from "jsr:@std/path@1.0.1";
 import { _internal, getConfig } from "./conf.ts";
 
 const ENV_VARS: Readonly<Record<string, string | undefined>> = {

--- a/denops.ts
+++ b/denops.ts
@@ -1,10 +1,11 @@
-import type { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@6.0.6";
+import type { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@7.0.0";
 import type { Client } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
 
 export class DenopsImpl implements Denops {
   readonly name: string;
   readonly meta: Meta;
   readonly context: Record<string | number | symbol, unknown> = {};
+  readonly interrupted = AbortSignal.any([]);
 
   dispatcher: Dispatcher = {};
 

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "jsr:@denops/core@6.0.6";
+import type { Denops } from "jsr:@denops/core@7.0.0";
 import { assert, ensure, is } from "jsr:@core/unknownutil@3.18.0";
 import { Client, Session } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
 import { errorDeserializer, errorSerializer } from "./error.ts";

--- a/runner.ts
+++ b/runner.ts
@@ -1,4 +1,4 @@
-import { mergeReadableStreams } from "jsr:@std/streams@0.224.0/merge-readable-streams";
+import { mergeReadableStreams } from "jsr:@std/streams@0.224.5/merge-readable-streams";
 import { is } from "jsr:@core/unknownutil@3.18.0";
 import { unreachable } from "jsr:@lambdalisue/errorutil@1.0.0";
 import { type Config, getConfig } from "./conf.ts";

--- a/stub.ts
+++ b/stub.ts
@@ -1,4 +1,4 @@
-import type { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@6.0.6";
+import type { Context, Denops, Dispatcher, Meta } from "jsr:@denops/core@7.0.0";
 
 /**
  * Represents a stubber object for `Denops`.
@@ -22,6 +22,12 @@ export interface DenopsStubber {
    * ```
    */
   meta?: Meta;
+
+  /**
+   * AbortSignal instance that is triggered when the user invoke `denops#interrupt()`
+   * If not specified, it returns a new instance of `AbortSignal`.
+   */
+  interrupted?: AbortSignal;
   /**
    * A stub function for the `redraw` method of `Denops`.
    * If not specified, it returns a promise resolving to undefined.
@@ -94,6 +100,10 @@ export class DenopsStub implements Denops {
       version: "0.0.0",
       platform: "linux",
     };
+  }
+
+  get interrupted(): AbortSignal {
+    return this.#stubber.interrupted ?? AbortSignal.any([]);
   }
 
   /**

--- a/stub_test.ts
+++ b/stub_test.ts
@@ -1,6 +1,6 @@
-import { assertSpyCall, spy } from "jsr:@std/testing@0.224.0/mock";
-import { assertEquals } from "jsr:@std/assert@0.225.1";
-import type { Denops } from "jsr:@denops/core@6.0.6";
+import { assertSpyCall, spy } from "jsr:@std/testing@0.225.3/mock";
+import { assertEquals } from "jsr:@std/assert@1.0.0";
+import type { Denops } from "jsr:@denops/core@7.0.0";
 import { DenopsStub } from "./stub.ts";
 
 Deno.test("`DenopsStub`", async (t) => {

--- a/tester.ts
+++ b/tester.ts
@@ -1,5 +1,5 @@
-import { sample } from "jsr:@std/collections@0.224.1/sample";
-import type { Denops } from "jsr:@denops/core@6.0.6";
+import { sample } from "jsr:@std/collections@1.0.5/sample";
+import type { Denops } from "jsr:@denops/core@7.0.0";
 import type { RunMode } from "./runner.ts";
 import { withDenops } from "./with.ts";
 

--- a/tester_test.ts
+++ b/tester_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertFalse,
   assertThrows,
-} from "jsr:@std/assert@0.225.1";
+} from "jsr:@std/assert@1.0.0";
 import { test } from "./tester.ts";
 
 test({

--- a/with.ts
+++ b/with.ts
@@ -1,7 +1,7 @@
-import { deadline } from "jsr:@std/async@0.224.0/deadline";
+import { deadline } from "jsr:@std/async@1.0.0/deadline";
 import { assert, is } from "jsr:@core/unknownutil@3.18.0";
 import { Client, Session } from "jsr:@lambdalisue/messagepack-rpc@2.1.1";
-import type { Denops, Meta } from "jsr:@denops/core@6.0.6";
+import type { Denops, Meta } from "jsr:@denops/core@7.0.0";
 import { getConfig } from "./conf.ts";
 import { run, type RunMode } from "./runner.ts";
 import { DenopsImpl } from "./denops.ts";

--- a/with_test.ts
+++ b/with_test.ts
@@ -4,9 +4,9 @@ import {
   assertEquals,
   assertFalse,
   assertRejects,
-} from "jsr:@std/assert@0.225.1";
-import { assertSpyCalls, spy, stub } from "jsr:@std/testing@0.224.0/mock";
-import type { Denops } from "jsr:@denops/core@6.0.6";
+} from "jsr:@std/assert@1.0.0";
+import { assertSpyCalls, spy, stub } from "jsr:@std/testing@0.225.3/mock";
+import type { Denops } from "jsr:@denops/core@7.0.0";
 import { withDenops } from "./with.ts";
 
 Deno.test("test(mode:vim) start vim to test denops features", async () => {


### PR DESCRIPTION
SSIA

## Ref

- https://github.com/vim-denops/denops.vim/pull/344
- https://github.com/vim-denops/deno-denops-core/pull/8
- https://github.com/vim-denops/deno-denops-std/pull/246
- https://github.com/vim-denops/deno-denops-test/pull/25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `interrupted` property to enhance control flow within the application.

- **Updates**
  - Upgraded `Denops` module from version `6.0.6` to `7.0.0` to ensure compatibility with the latest features and improvements.
  - Updated various dependencies to their latest versions for improved performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->