### PR TITLE
:bug: Use `denops-test` as a default plugin name

### DIFF
--- a/tester_test.ts
+++ b/tester_test.ts
@@ -88,7 +88,7 @@ test({
   fn: (denops) => {
     assertEquals(
       denops.name,
-      "@denops-test",
+      "denops-test",
     );
   },
 });

--- a/with.ts
+++ b/with.ts
@@ -7,7 +7,7 @@ import { run, type RunMode } from "./runner.ts";
 import { DenopsImpl } from "./denops.ts";
 import { errorDeserializer, errorSerializer } from "./error.ts";
 
-const PLUGIN_NAME = "@denops-test";
+const PLUGIN_NAME = "denops-test";
 
 // Timeout for connecting to Vim/Neovim
 // It takes a long time to start Vim/Neovim on Windows, so set a long timeout


### PR DESCRIPTION
Because Denops v7 restrict a plugin name.

https://github.com/vim-denops/denops.vim/pull/344/commits/fa4d6785b37a25e6e66e53e649aee5d5f158bf79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the name assertion in the test for improved consistency and clarity.
- **New Features**
	- Renamed the plugin from `@denops-test` to `denops-test` for better identification and reference across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->