### PR TITLE
:coffee: Add --config option to deno cache command in workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ on:
   workflow_dispatch:
     inputs:
       denops_branch:
-        description: 'Denops revision to test'
+        description: "Denops revision to test"
         required: false
-        default: 'main'
+        default: "main"
       verbose:
         type: boolean
         required: false
-        description: 'Enable verbose output'
+        description: "Enable verbose output"
         default: false
 
 defaults:
@@ -129,7 +129,8 @@ jobs:
 
       - name: Perform pre-cache
         run: |
-          deno cache ${DENOPS_TEST_DENOPS_PATH}/denops/@denops-private/mod.ts ./mod.ts
+          deno cache --config ${DENOPS_TEST_DENOPS_PATH}/denops/@denops-private/deno.jsonc ${DENOPS_TEST_DENOPS_PATH}/denops/@denops-private/mod.ts
+          deno cache ./mod.ts
 
       - name: Run tests
         run: deno task test:coverage

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ on:
   workflow_dispatch:
     inputs:
       denops_branch:
-        description: 'Denops branch to test'
+        description: "Denops branch to test"
         required: false
-        default: 'main'
+        default: "main"
 
 # Use 'bash' as default shell even on Windows
 defaults:
@@ -177,7 +177,7 @@ jobs:
 
       - name: Perform pre-cache
         run: |
-          deno cache ${DENOPS_TEST_DENOPS_PATH}/denops/@denops-private/mod.ts
+          deno cache --config ${DENOPS_TEST_DENOPS_PATH}/denops/@denops-private/deno.jsonc ${DENOPS_TEST_DENOPS_PATH}/denops/@denops-private/mod.ts
           deno cache ./denops/your_plugin/main.ts
 
       - name: Run tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reflect changes in workflow input formatting and caching commands.
* **Chores**
  * Modified workflow configuration to use double quotes for input descriptions and defaults.
  * Adjusted caching steps to separate cache commands and specify a configuration file for one of the commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->